### PR TITLE
Only load a subset of columns from the MANC dataset files to reduce memory usage

### DIFF
--- a/vnc_networks/connections.py
+++ b/vnc_networks/connections.py
@@ -609,7 +609,7 @@ class Connections:
             split_neurons: list[Neuron] = None,
             not_connected: list[int] = None, # body ids
             ):
-        if split_neurons is not None:
+        if split_neurons is not None and not_connected is not None:
             for neuron in split_neurons:
                 neuron.clear_not_connected(not_connected)
         self.__get_connections()

--- a/vnc_networks/connections.py
+++ b/vnc_networks/connections.py
@@ -59,7 +59,7 @@ class Connections:
             self.__load(from_file)
         else:
             if neurons_pre is None:
-                neurons_ = pd.read_feather(params.NEUPRINT_NODES_FILE)
+                neurons_ = pd.read_feather(params.NEUPRINT_NODES_FILE, columns=[':ID(Body-ID)'])
                 neurons_pre_ = neurons_[':ID(Body-ID)'].to_list()
 
             else:
@@ -83,7 +83,7 @@ class Connections:
         self.__dict__.update(neuron)
 
     def __get_connections(self):
-        connections_ = pd.read_feather(params.NEUPRINT_CONNECTIONS_FILE)
+        connections_ = pd.read_feather(params.NEUPRINT_CONNECTIONS_FILE, columns=[':START_ID(Body-ID)','weightHR:int',':END_ID(Body-ID)'])
         # filter out only the connections relevant here
         connections_ = connections_[
             connections_[":START_ID(Body-ID)"].isin(

--- a/vnc_networks/get_nodes_data.py
+++ b/vnc_networks/get_nodes_data.py
@@ -15,7 +15,8 @@ def get_neuron_bodyids(
     Select (keep) according to the selection_dict.
     Different criteria are treated as 'and' conditions.
     """
-    neurons = pd.read_feather(params.NEUPRINT_NODES_FILE)
+    columns_to_read = {':ID(Body-ID)'}.union(selection_dict.keys()) if selection_dict is not None else {':ID(Body-ID)'}
+    neurons = pd.read_feather(params.NEUPRINT_NODES_FILE, columns=list(columns_to_read))
     if selection_dict is not None:
         for key in selection_dict:
             neurons = neurons[neurons[key] == selection_dict[key]]
@@ -55,7 +56,8 @@ def load_data_neuron(id_: int, attributes: list = None) -> pd.DataFrame:
     pandas.DataFrame
         The data of the neuron.
     """
-    neurons = pd.read_feather(params.NEUPRINT_NODES_FILE)
+    columns_to_read = {':ID(Body-ID)'}.union(attributes) if attributes is not None else {':ID(Body-ID)'}
+    neurons = pd.read_feather(params.NEUPRINT_NODES_FILE, columns=list(columns_to_read))
     if attributes is not None:
         if attributes not in neurons.columns:
             raise ValueError(
@@ -85,7 +87,8 @@ def load_data_neuron_set(ids: list, attributes: list = None) -> pd.DataFrame:
     pandas.DataFrame
         The data of the neurons.
     """
-    neurons = pd.read_feather(params.NEUPRINT_NODES_FILE)
+    columns_to_read = {':ID(Body-ID)'}.union(attributes) if attributes is not None else {':ID(Body-ID)'}
+    neurons = pd.read_feather(params.NEUPRINT_NODES_FILE, columns=list(columns_to_read))
     if attributes is not None:
         # verify if all elements of 'attributes' are columns in the dataset
         for att in attributes:

--- a/vnc_networks/neuron.py
+++ b/vnc_networks/neuron.py
@@ -90,7 +90,7 @@ class Neuron:
         """
         # neuron to synapse set
         neuron_to_synapse = pd.read_feather(
-            params.NEUPRINT_NEURON_SYNAPSESSET_FILE, columns=[':START_ID(Body-ID)']
+            params.NEUPRINT_NEURON_SYNAPSESSET_FILE
             )
         synset_list = neuron_to_synapse.loc[
             neuron_to_synapse[':START_ID(Body-ID)'] == self.bodyId

--- a/vnc_networks/neuron.py
+++ b/vnc_networks/neuron.py
@@ -20,6 +20,21 @@ import params
 from  get_nodes_data import load_data_neuron
 import utils.plots_design as plot_design
 
+NEURON_BASE_ATTRIBUTES = [
+    'systematicType:string', 
+    'hemilineage:string', 
+    'somaSide:string', 
+    'class:string', 
+    'subclass:string', 
+    'group:int', 
+    'cellBodyFiber:string', 
+    'size:long', 
+    'target:string', 
+    'predictedNtProb:float', 
+    'predictedNt:string', 
+    'tag:string',
+]
+
 class Neuron:
     def __init__(self, bodyId: int = None, from_file: str = None):
         """
@@ -42,7 +57,7 @@ class Neuron:
             self.__load(from_file)
         else:
             self.bodyId = bodyId
-            self.data = load_data_neuron(bodyId)
+            self.data = load_data_neuron(bodyId, NEURON_BASE_ATTRIBUTES)
             self.__initialise_base_attributes()
 
     # private methods

--- a/vnc_networks/neuron.py
+++ b/vnc_networks/neuron.py
@@ -75,7 +75,7 @@ class Neuron:
         """
         # neuron to synapse set
         neuron_to_synapse = pd.read_feather(
-            params.NEUPRINT_NEURON_SYNAPSESSET_FILE
+            params.NEUPRINT_NEURON_SYNAPSESSET_FILE, columns=[':START_ID(Body-ID)']
             )
         synset_list = neuron_to_synapse.loc[
             neuron_to_synapse[':START_ID(Body-ID)'] == self.bodyId
@@ -129,7 +129,7 @@ class Neuron:
         """
         # load the synapse data
         data = pd.read_feather(
-            params.NEUPRINT_SYNAPSE_FILE
+            params.NEUPRINT_SYNAPSE_FILE, columns=[':ID(Syn-ID)','location:point{srid:9157}']
             )
         data = data.loc[data[':ID(Syn-ID)'].isin(self.synapse_df['syn_id'])]
               

--- a/vnc_networks/neuron.py
+++ b/vnc_networks/neuron.py
@@ -142,9 +142,17 @@ class Neuron:
             The subset of synapse ids to convert.
             The default is None, which converts all synapse ids.
         """
+        # we also need to load these columns because they get used in create_synapse_groups / __categorical_neuropil_information
+        roi_file = os.path.join(
+            params.NEUPRINT_RAW_DIR,
+            'all_ROIs.txt'
+        )
+        rois = list(pd.read_csv(roi_file, sep='\t').values.flatten())
+        potential_column_names = [roi + ':boolean' for roi in rois]
+
         # load the synapse data
         data = pd.read_feather(
-            params.NEUPRINT_SYNAPSE_FILE, columns=[':ID(Syn-ID)','location:point{srid:9157}']
+            params.NEUPRINT_SYNAPSE_FILE, columns=[':ID(Syn-ID)','location:point{srid:9157}']+potential_column_names
             )
         data = data.loc[data[':ID(Syn-ID)'].isin(self.synapse_df['syn_id'])]
               


### PR DESCRIPTION
Reading the MANC Neurprint datasets using `pd.read_feather` was using a lot of memory, particularly loading the neurons or synapses:

* `Neuprint_Synapses_manc_v1.ftr` - (97M * 70) - 172 GB
* `Neuprint_Neurons_manc_v1.ftr` - (24M * 109) - 61 GB
* `Neuprint_SynapseSet_to_Synapses_manc_v1.ftr` - (174M * 2) - 15 GB
* `Neuprint_Neuron_to_SynapseSet_manc_v1.ftr` - (85M * 2) - 2 GB
* `Neuprint_Neuron_Connections_manc_v1.ftr` - (42M * 6) - 5 GB

The `read_feather` function allows you to specify which columns to read in, and mostly we were only using a few and throwing away the rest. So I used this approach to significantly reduce the memory usage. Now it should run with ~16 GB of memory.

One question I have is with the `Neuron.__load_synapse_locations` function - this merges the data from the Synapses dataframe with the data for a particular neuron's synapses. I checked the current usage to see which columns were being used, but I'm not sure if I missed some.