### PR TITLE
Specify version of pyvis with encoding bug fixed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = [
   "matplotlib-venn",
   "scikit-learn",
   "networkx",
-  "pyvis",
+  # need the fix from https://github.com/WestHealth/pyvis/pull/222 to fix an error in windows
+  "pyvis @ git+https://github.com/leshabirukov/pyvis@issue/force-utf-8-in-write-html",
   "pyarrow",
   "setuptools",
   "tqdm",


### PR DESCRIPTION
Got `UnicodeDecodeError` when using pyvis for interactive network visualisation on windows - https://github.com/WestHealth/pyvis/pull/222

The PR with the fix wasn't merged in so we manually specify this version in our dependencies