### PR TITLE
Add option not to ignore zero weight synapses when searching for paths between neurons

### DIFF
--- a/vnc_networks/connections.py
+++ b/vnc_networks/connections.py
@@ -1521,6 +1521,7 @@ class Connections:
         source: UID | int | list[UID] | list[int],
         target: UID | int | list[UID] | list[int],
         syn_threshold: Optional[int] = None,
+        ignore_zero_weight_synapses: bool = True,
     ):
         """
         Get the graph with all the paths of length n between two sets of nodes.
@@ -1533,8 +1534,13 @@ class Connections:
             List of source nodes.
         target: list[int]
             List of target nodes.
-        syn_threshold: int
-            Threshold for the synapse count.
+        syn_threshold: int, optional
+            Threshold for the synapse count. Paths with fewer than this many synapses
+            will be ignored. If not provided, don't filter paths by synapse count.
+        ignore_zero_weight_synapses: bool, optional
+            Whether to ignore synapses with a weight of zero in the paths.
+            These are typically neuromodulatory synapses.
+
 
         Returns
         -------
@@ -1562,7 +1568,9 @@ class Connections:
                 if self.graph[edge[0]][edge[1]]["syn_count"] >= syn_threshold
             ]
         # Create the subgraph
-        return nx_utils.get_subgraph_from_edges(self.graph, edges_)
+        return nx_utils.get_subgraph_from_edges(
+            self.graph, edges_, ignore_zero_weight_synapses
+        )
 
     def cluster_hierarchical(
         self, reference: typing.Literal["norm", "unnorm", "syn_count"] = "syn_count"

--- a/vnc_networks/utils/nx_utils.py
+++ b/vnc_networks/utils/nx_utils.py
@@ -44,18 +44,37 @@ def get_subgraph(graph: nx.DiGraph, nodes: list) -> nx.DiGraph:
     return graph_.subgraph(nodes)
 
 
-def get_subgraph_from_edges(graph: nx.DiGraph, edges: list) -> nx.DiGraph:
+def get_subgraph_from_edges(
+    graph: nx.DiGraph, edges: list, remove_zero_weight_synapses: bool = True
+) -> nx.DiGraph:
     """
-    Get the subgraph of the graph containing only the nodes in the list.
+
+    Get the subgraph of the graph containing only the edges in the list.
+
+    Parameters
+    ----------
+    graph: nx.DiGraph
+        The graph from which to make the subgraph
+    edges: list
+        The list of edges in the graph to be kept
+    remove_zero_weight_synapses: bool, optional
+        Whether to remove neuromodulatory synapses from the graph. The have a weight of 0,
+        because it's unknown whether they're excitatory of inhibitory. Defaults to True.
+
+    Returns
+    -------
+    nx.DiGraph
+        A subgraph of the original graph, returned as a copy.
     """
     graph_ = graph.edge_subgraph(edges).copy()
     assert isinstance(graph_, nx.DiGraph)  # needed for type hinting
-    # remove edges that have a weight of 0
-    edges_to_remove = []
-    for edge in graph_.edges():
-        if abs(graph_.edges[edge]["weight"]) < 1:
-            edges_to_remove.append(edge)
-    graph_.remove_edges_from(edges_to_remove)
+    if remove_zero_weight_synapses:
+        # remove edges that have a weight of 0
+        edges_to_remove = []
+        for edge in graph_.edges():
+            if abs(graph_.edges[edge]["weight"]) < 1:
+                edges_to_remove.append(edge)
+        graph_.remove_edges_from(edges_to_remove)
     # nodes that are not connected to any other node are removed
     nodes_to_remove = []
     for node in graph_.nodes():


### PR DESCRIPTION
Fixes #48

This adds a parameter to the `nx_utils.get_subgraph_from_edges` function to not remove the connections with weight 0, and a parameter to `connections.paths_length_n` to do the same.

These flags are optional and default to removing these nodes, so existing code relying on this behaviour won't break.