### PR TITLE
Set min python version to 3.10

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10","3.11","3.12"]
+        python-version: ["3.10","3.11","3.12","3.13"]
 
     steps:
     - uses: actions/checkout@v4
@@ -31,14 +31,13 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
-        pip install -e .
+        pip install -e ".[dev]"
     - name: Install the code linting and formatting tool Ruff
       run: pipx install ruff
     - name: Lint code with Ruff
-      run: ruff check --output-format=github --target-version=py39
+      run: ruff check --output-format=github --target-version=py310
     - name: Check code formatting with Ruff
-      run: ruff format --diff --target-version=py39
+      run: ruff format --diff --target-version=py310
       continue-on-error: true
     - name: Debug test discovery
       run: pytest --collect-only

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,16 +5,15 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "vnc_networks"
 version = "0.0.1"
-authors = [
-  { name="Femke Hurtak", email="femke.hurtak@epfl.ch" },
-]
+authors = [{ name = "Femke Hurtak", email = "femke.hurtak@epfl.ch" }]
 classifiers = [
-    "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
-    "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent",
 ]
 readme = "README.md"
 description = "Package to work with connectomes for network modelling"
+requires-python = ">=3.10"
 dependencies = [
   "pandas",
   "numpy",
@@ -32,6 +31,7 @@ dependencies = [
   "markov_clustering",
   "bidict",
 ]
+optional-dependencies = { dev = ["pytest", "ruff>=0.12"] }
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/scripts/dn_matching.ipynb
+++ b/scripts/dn_matching.ipynb
@@ -2662,7 +2662,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -2675,7 +2675,7 @@
    ],
    "source": [
     "print(\n",
-    "    f\"{sum([len(matches[\"LHS\"])+len(matches[\"RHS\"]) > 0 for matches in manc_to_fafb_map_combined_sides.values()])}/{len(dn_names_manc_unique)} of the unique MANC names have FAFB matches\"\n",
+    "    f\"{sum([len(matches['LHS'])+len(matches['RHS']) > 0 for matches in manc_to_fafb_map_combined_sides.values()])}/{len(dn_names_manc_unique)} of the unique MANC names have FAFB matches\"\n",
     ")"
    ]
   },

--- a/scripts/fafb_missing_some_synapses.ipynb
+++ b/scripts/fafb_missing_some_synapses.ipynb
@@ -239,7 +239,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "676a805a",
    "metadata": {},
    "outputs": [
@@ -259,11 +259,11 @@
     "):\n",
     "    c = vnc_networks.connections.Connections(connectome_reader)\n",
     "    print(\n",
-    "        f\"connections table has {len(c.connections)} connections with {c.connections[\"syn_count\"].sum()} synapses\"\n",
+    "        f\"connections table has {len(c.connections)} connections with {c.connections['syn_count'].sum()} synapses\"\n",
     "    )\n",
     "    print(\n",
     "        f\"connections graph has {len(c.graph.edges)} connections with {sum(\n",
-    "        c.graph.edges[e][\"syn_count\"] for e in c.graph.edges\n",
+    "        c.graph.edges[e]['syn_count'] for e in c.graph.edges\n",
     "    )} synapses\"\n",
     "    )\n",
     "\n",
@@ -308,7 +308,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "d064083e",
    "metadata": {},
    "outputs": [
@@ -321,9 +321,9 @@
     }
    ],
    "source": [
-    "connections_table_synapses = connections_table[\"syn_count\"].sum()\n",
+    "connections_table_synapses = connections_table['syn_count'].sum()\n",
     "graph_synapses = sum(\n",
-    "    connections.graph.edges[e][\"syn_count\"] for e in connections.graph.edges\n",
+    "    connections.graph.edges[e]['syn_count'] for e in connections.graph.edges\n",
     ")\n",
     "\n",
     "print(\n",
@@ -528,7 +528,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "4ee1b8eb",
    "metadata": {},
    "outputs": [
@@ -543,11 +543,11 @@
    ],
    "source": [
     "print(\n",
-    "        f\"connections table has {len(connections.connections)} connections with {connections.connections[\"syn_count\"].sum()} synapses\"\n",
+    "        f\"connections table has {len(connections.connections)} connections with {connections.connections['syn_count'].sum()} synapses\"\n",
     "    )\n",
     "print(\n",
     "    f\"connections graph has {len(fafb_multigraph.edges)} connections with {sum(\n",
-    "    fafb_multigraph.edges[e][\"syn_count\"] for e in fafb_multigraph.edges\n",
+    "    fafb_multigraph.edges[e]['syn_count'] for e in fafb_multigraph.edges\n",
     ")} synapses\"\n",
     ")\n"
    ]


### PR DESCRIPTION
Python 3.9 is nearly end of life and it doesn't let us use match statements.

We have these in `cmatrix.py` so this code wouldn't have worked anyway,

This just got picked up by a newer version of `ruff`.